### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/searcher.el
+++ b/searcher.el
@@ -35,6 +35,8 @@
 (require 'cl-lib)
 (require 'dash)
 (require 'f)
+(require 'subr-x)
+(require 'grep)
 
 (defgroup searcher nil
   "Searcher in pure elisp."


### PR DESCRIPTION
```
In searcher--f-directories-ignore-directories:
searcher.el:82:29:Warning: reference to free variable
    ‘grep-find-ignored-directories’

In end of data:
searcher.el:152:1:Warning: the function ‘string-empty-p’ is not known to be
    defined.
```